### PR TITLE
rename setTag

### DIFF
--- a/src/Core/IMeasurement.cs
+++ b/src/Core/IMeasurement.cs
@@ -18,5 +18,5 @@ namespace Mindbox.DiagnosticContext;
 
 public interface IMeasurement : IDisposable
 {
-	IMeasurement SetTag(string tag, string value);
+	IMeasurement SetTraceTag(string tag, string value);
 }

--- a/src/Core/IMeasurement.cs
+++ b/src/Core/IMeasurement.cs
@@ -18,5 +18,5 @@ namespace Mindbox.DiagnosticContext;
 
 public interface IMeasurement : IDisposable
 {
-	IMeasurement SetTraceTag(string tag, string value);
+	IMeasurement SetSpanAttribute(string attribute, string value);
 }

--- a/src/Core/NullMeasurementTagsAdapter.cs
+++ b/src/Core/NullMeasurementTagsAdapter.cs
@@ -25,7 +25,7 @@ internal class NullMeasurementTagsAdapter : IMeasurement
 		_original = original;
 	}
 
-	public IMeasurement SetTag(string tag, string value)
+	public IMeasurement SetTraceTag(string tag, string value)
 	{
 		return this;
 	}

--- a/src/Core/NullMeasurementTagsAdapter.cs
+++ b/src/Core/NullMeasurementTagsAdapter.cs
@@ -25,7 +25,7 @@ internal class NullMeasurementTagsAdapter : IMeasurement
 		_original = original;
 	}
 
-	public IMeasurement SetTraceTag(string tag, string value)
+	public IMeasurement SetSpanAttribute(string attribute, string value)
 	{
 		return this;
 	}


### PR DESCRIPTION
В рамках https://github.com/mindbox-cloud/issues-loyalty/issues/4944 переименовываем добавлени тега в трейсы

Не поняла как тут dev-pack собрать, видимо придется это выпускать а потом по очереди поднимать версии и делать изменения даньше. 

Что затронет это изменения и какие пр дальше
1. В Mindbox.AspNetCore подтянуть новую версию, переименовать  [тут 2 метода ](https://github.com/search?q=repo%3Amindbox-cloud%2FMindbox.AspNetCore%20IMeasurement%20SetTag&type=code), выпустить пакет
2. В cdp подтянуть новый пакет, исправить вызовы [тут](https://github.com/mindbox-cloud/DirectCRM/blob/ef122e4f4c15e6ceef7971416fa97d7ec3d33208/src/Product/DirectCrm/DirectCrm.Model/Operations/Steps/Entities/New/RetailOrder/Actions/CalculateOrderAction.cs#L227). 
пр буду присылать по мере их последовательного выхода

На этом переименование должно закончится - вроде эта функция больше нигде не используется. 

После переименования использую ее еще для задания transactionId операции в cdp и po.

